### PR TITLE
fix: Reset `hasVoted` status along with votes when a new story is selected

### DIFF
--- a/app/api/rooms/[code]/stories/[storyId]/select/route.ts
+++ b/app/api/rooms/[code]/stories/[storyId]/select/route.ts
@@ -53,6 +53,7 @@ export async function POST(
         const resetParticipants = participants.map((p: any) => ({
             ...p,
             vote: null,
+            hasVoted: false,
         }));
 
         await roomRef.update({


### PR DESCRIPTION
Closes #6 